### PR TITLE
fix(deployment): prevent secretRef conflict when existingSecret is defined

### DIFF
--- a/charts/powerdns-operator/templates/deployment.yaml
+++ b/charts/powerdns-operator/templates/deployment.yaml
@@ -86,8 +86,7 @@ spec:
         {{- if .Values.credentials.existingSecret }}
         - secretRef:
             name: {{ .Values.credentials.existingSecret }}
-        {{- end }}
-        {{- if .Values.credentials.name }}
+        {{- else if .Values.credentials.name }}
         - secretRef:
             name: {{ .Values.credentials.name }}
         {{- end }}


### PR DESCRIPTION
This change ensures that only one of the conditions (existingSecret or name) is applied in the Helm chart, preventing both conditions from being applied simultaneously.

## Values

```yaml
credentials:
  # -- Specifies whether to use an existing secret.
  existingSecret: "my-custom-secret"
```

## Current Result

```
        command:
        - /manager
        envFrom:
        - secretRef:
            name: my-custom-secret
        - secretRef:
            name: powerdns-api-credentials
        image: ghcr.io/orange-opensource/powerdns-operator:v0.4.1
        imagePullPolicy: IfNotPresent
```

## Expected Result

```
        command:
        - /manager
        envFrom:
        - secretRef:
            name: my-custom-secret
        image: ghcr.io/orange-opensource/powerdns-operator:v0.4.1
        imagePullPolicy: IfNotPresent
```


Alternatively, the current workaround is to set `.Values.credentials.name` to an empty string.
```yaml
credentials:
  existingSecret: "my-custom-secret"
  name: "" # empty
```